### PR TITLE
Add role config

### DIFF
--- a/doc.json
+++ b/doc.json
@@ -9,9 +9,15 @@
       "default": true
     },
     "authorized-users": {
-      "description": "List of players who can always commands",
+      "description": "List of players who can always use commands",
       "type": "players",
       "default": []
+    },
+    "authorized-roles": {
+      "description": "List of roles who can always use commands",
+      "type": "list",
+      "itemType": "role",
+      "default": ["Admin"]
     },
     "cooldown": {
       "description": "How long before users can re-run the command (seconds)",

--- a/omegga.plugin.ts
+++ b/omegga.plugin.ts
@@ -10,6 +10,7 @@ const textFonts = {};
 type Config = {
   'only-authorized': boolean;
   'authorized-users': { id: string; name: string }[];
+  'authorized-roles': string [];
   cooldown: number;
 };
 type Storage = {};
@@ -54,7 +55,8 @@ export default class TextGen implements OmeggaPlugin<Config, Storage> {
       return (
         !this.config['only-authorized'] ||
         player.isHost() ||
-        this.config['authorized-users'].some(p => player.id === p.id)
+        this.config['authorized-users'].some(p => player.id === p.id) ||
+        player.getRoles().some(role => this.config['authorized-roles'].includes(role))
       );
     };
 


### PR DESCRIPTION
This adds `authorized-roles` to the config, and additionally fixes a typo in `authorized-users`'s description.